### PR TITLE
Update autoload.php

### DIFF
--- a/application/config/autoload.php
+++ b/application/config/autoload.php
@@ -58,7 +58,7 @@ $autoload['packages'] = array();
 |
 |	$autoload['libraries'] = array('user_agent' => 'ua');
 */
-$autoload['libraries'] = array('database', 'jalalicalendar');
+$autoload['libraries'] = array('database', 'JalaliCalendar');
 
 /*
 | -------------------------------------------------------------------


### PR DESCRIPTION
In Windows, uppercase letters in paths do not matter. But this is not the case in Linux.
due to such an oversight, an error occurs: An Error Was Encountered
Unable to load the requested class: Jalalicalendar